### PR TITLE
Improve autocomplete when using resolve

### DIFF
--- a/src/InterfaceResolver/ResolverInterface.php
+++ b/src/InterfaceResolver/ResolverInterface.php
@@ -13,10 +13,12 @@ interface ResolverInterface
      * Resolve the given interface and return the corresponding
      * service from the service container.
      *
+     * @param class-string<T> $interface
      * @param mixed $version
-     * @phpstan-param class-string $interface
      *
-     * @return mixed
+     * @return T
+     *
+     * @template T
      */
     public function resolve(string $interface, $version = 'latest');
 


### PR DESCRIPTION
Currently, the `resolve` method returns `mixed`, but it's actually the resolved instance of the interface passed by parameter. 
So a generic can help to have the correct type returned by the method.